### PR TITLE
Update builder.sh with latest clang r487747c

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -18,7 +18,7 @@ TARGET_IMAGE="Image.gz-dtb"
 TARGET_DTBO="dtbo.img"
 
 # Toolchains
-CLANG_VERSION="clang-r487747" # https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/heads/master/clang-r487747/
+CLANG_VERSION="clang-r487747c" # https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/heads/master/clang-r487747c/
 CLANG_LOC="/home/pwnrazr/dev-stuff/${CLANG_VERSION}"
 CLANG="${CLANG_LOC}/bin:$PATH"
 CT_BIN="${CLANG}/bin/"


### PR DESCRIPTION
https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/heads/master/clang-r487747c/

r487747 is dropped by AOSP team